### PR TITLE
doc(build-deps): update postgres link

### DIFF
--- a/src/2-Build-and-Installation-Guide/2.1-Sensys-Build-and-Installation/2.1.01-Build-Dependencies.md
+++ b/src/2-Build-and-Installation-Guide/2.1-Sensys-Build-and-Installation/2.1.01-Build-Dependencies.md
@@ -111,7 +111,7 @@ Installation instructions for these components depends on the Linux distribution
 
 To download and install use:
 ```
-% yum localinstall http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-centos93-9.3-1.noarch.rpm
+% yum localinstall http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/pgdg-centos93-9.3-3.noarch.rpm
 ```
 For more information on unixODBC, please refer to: [unixODBC](http://www.unixodbc.org/).
 


### PR DESCRIPTION
pgdg-centos93-9.3-1.noarch.rpm is no longer hosted on that server, but pgdg-centos93-9.3-3.noarch.rpm is.